### PR TITLE
Support releasing a subset of proc type images (v1.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ steps:
     plugins:
       - envato/heroku-container-deploy#v1.0.0:
           app: my-app
-          process-types:
+          process-type-images:
             - web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web-${BUILDKITE_COMMIT}
 ```
 
@@ -28,7 +28,7 @@ steps:
     plugins:
       - envato/heroku-container-deploy#v1.0.0:
           app: my-app
-          process-types:
+          process-type-images:
             - web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web-${BUILDKITE_COMMIT}
             - worker:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-worker-${BUILDKITE_COMMIT}
 ```
@@ -41,7 +41,7 @@ steps:
     plugins:
       - envato/heroku-container-deploy#v1.0.0:
           app: my-app
-          process-types:
+          process-type-images:
             - web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web-${BUILDKITE_COMMIT}
             - worker:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-worker-${BUILDKITE_COMMIT}
             - release:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release-${BUILDKITE_COMMIT}
@@ -55,7 +55,7 @@ Ensure that you have an `HEROKU_API_KEY` environment variable configured for you
 
 Heroku app name
 
-### `process-types` (Required, Array of string)
+### `process-type-images` (Required, Array of string)
 
 List of process types and their image repository to deploy.
 
@@ -63,9 +63,11 @@ List of process types and their image repository to deploy.
 <proc-type>:<ecr>:<tag>
 ```
 
-### `skip-release-types` (Optional, Array of string)
+### `releasing` (Optional, Array of string)
 
-List of process type names to skip releasing. It will pull, tag and push these images, but it won't patch the Heroku Formation API with these image ids.
+List of process type names to be released. It will allays pull, tag and push all images, but it will only patch the Heroku Formation API with these images.
+
+Default: All process types in `process-type-images`
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Deploy a pre-built images from ECR to heroku container registry.
 steps:
   - label: ":heroku: Deploy my-app app (web)"
     plugins:
-      - envato/heroku-container-deploy#v1.0.0:
+      - envato/heroku-container-deploy#v1.1.0:
           app: my-app
           process-type-images:
             - web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web-${BUILDKITE_COMMIT}
@@ -26,7 +26,7 @@ Deploy multiple pre-built images from ECR to heroku container registry.
 steps:
   - label: ":heroku: Deploy my-app app (web and worker)"
     plugins:
-      - envato/heroku-container-deploy#v1.0.0:
+      - envato/heroku-container-deploy#v1.1.0:
           app: my-app
           process-type-images:
             - web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web-${BUILDKITE_COMMIT}
@@ -39,7 +39,7 @@ Deploy multiple pre-built images including a [Release Phase](https://devcenter.h
 steps:
   - label: ":heroku: Deploy my-app app (web, worker and release)"
     plugins:
-      - envato/heroku-container-deploy#v1.0.0:
+      - envato/heroku-container-deploy#v1.1.0:
           app: my-app
           process-type-images:
             - web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web-${BUILDKITE_COMMIT}

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ List of process types and their image repository to deploy.
 <proc-type>:<ecr>:<tag>
 ```
 
+### `skip-release-types` (Optional, Array of string)
+
+List of process type names to skip releasing. It will pull, tag and push these images, but it won't patch the Heroku Formation API with these image ids.
+
 ## Developing
 
 Testing

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ List of process types and their image repository to deploy.
 
 List of process type names to be released. It will allays pull, tag and push all images, but it will only patch the Heroku Formation API with these images.
 
-Default: All process types in `process-type-images`
+Default: All process types in `process-type-images` except one named `migrations`
 
 ## Developing
 

--- a/hooks/command
+++ b/hooks/command
@@ -137,7 +137,11 @@ proc_type_names=()
 for line in $process_types; do
   IFS=':' read -r -a tokens <<< "$line"
   proc_type=${tokens[0]}
-  proc_type_names+=("$proc_type")
+
+  # shellcheck disable=SC2076
+  if [[ ! " ${skip_release_types[*]} " =~ " ${proc_type} " ]]; then
+    proc_type_names+=("$proc_type")
+  fi
 done
 
 echo "+++ :heroku: Releasing ${proc_type_names[*]}"
@@ -152,11 +156,13 @@ for line in $process_types; do
 
   # Based on https://devcenter.heroku.com/articles/container-registry-and-runtime#getting-a-docker-image-id
   image_id=$(docker inspect "$proc_type_tag" --format=\{\{.Id\}\})
-  echo "Inspected $proc_type_tag identified as $image_id"
 
   # shellcheck disable=SC2076
   if [[ ! " ${skip_release_types[*]} " =~ " ${proc_type} " ]]; then
+    echo "Inspected $proc_type_tag identified as $image_id"
     updates+=("{\"type\":\"${proc_type}\",\"docker_image\":\"$image_id\"}")
+  else
+    echo "Skipping inspected $proc_type_tag identified as $image_id"
   fi
 done
 

--- a/hooks/command
+++ b/hooks/command
@@ -58,6 +58,8 @@ function get_proc_type_image_tag() {
 
 app=$(plugin_read_list APP)
 process_types=$(plugin_read_list PROCESS_TYPES)
+skip_release_types=$(plugin_read_list SKIP_RELEASE_TYPES)
+
 
 ##
 ## Pulling from owner container registry
@@ -147,12 +149,21 @@ for line in $process_types; do
   proc_type=${tokens[0]}
   proc_type_image=$(IFS=':'; echo "${tokens[*]:1}")
   proc_type_tag=$(get_proc_type_image_tag "$proc_type")
-  # Based on https://devcenter.heroku.com/articles/container-registry-and-runtime#getting-a-docker-image-id
-  image_id=$(docker inspect "$proc_type_tag" --format=\{\{.Id\}\})
 
-  echo "Inspected $proc_type_tag identified as $image_id"
-  updates+=("{\"type\":\"${proc_type}\",\"docker_image\":\"$image_id\"}")
+  # shellcheck disable=SC2076
+  if [[ ! " ${skip_release_types[*]} " =~ " ${proc_type} " ]]; then
+    # Based on https://devcenter.heroku.com/articles/container-registry-and-runtime#getting-a-docker-image-id
+    image_id=$(docker inspect "$proc_type_tag" --format=\{\{.Id\}\})
+
+    echo "Inspected $proc_type_tag identified as $image_id"
+    updates+=("{\"type\":\"${proc_type}\",\"docker_image\":\"$image_id\"}")
+  fi
 done
+
+if [ ${#updates[@]} -eq 0 ]; then
+  echo "There are no images to release"
+  exit 0
+fi
 
 payload=$(join_by , "${updates[@]}")
 
@@ -166,8 +177,6 @@ curl -sf -X PATCH "https://api.heroku.com/apps/$app/formation" \
   -H "Accept: application/vnd.heroku+json; version=3.docker-releases" \
   -H "Authorization: Bearer ${HEROKU_API_KEY:-}" \
   -o /dev/null
-
-echo ""
 
 version=""
 

--- a/hooks/command
+++ b/hooks/command
@@ -148,7 +148,7 @@ for line in "${process_type_images[@]}"; do
   proc_type_image=$(IFS=':'; echo "${tokens[*]:1}")
   proc_type_tag=$(get_proc_type_image_tag "$proc_type")
 
-  echo "~~~ :heroku: Pushing ${proc_type} image"
+  echo "~~~ :heroku: Pushing $app/$proc_type image"
   status=0
   if ! retry 3 docker push "$proc_type_tag"; then
     status=$((status + 1))
@@ -165,7 +165,7 @@ done
 ## Releasing to heroku platform
 ##
 
-echo "+++ :heroku: Releasing ${releasing[*]}"
+echo "+++ :heroku: Releasing ${releasing[*]} for $app"
 
 updates=()
 

--- a/hooks/command
+++ b/hooks/command
@@ -86,7 +86,10 @@ fi
 if [ ${#releasing[@]} -eq 0 ]; then
   for line in "${process_type_images[@]}"; do
     IFS=':' read -r -a tokens <<< "$line"
-    releasing+=("${tokens[0]}")
+    # Exclude an image called migrations by default
+    if [ "${tokens[0]}" != "migrations" ]; then
+      releasing+=("${tokens[0]}")
+    fi
   done
 fi
 

--- a/hooks/command
+++ b/hooks/command
@@ -59,28 +59,32 @@ function get_proc_type_image_tag() {
 app=$(plugin_read_list APP)
 
 process_type_images=()
-if [[ -n "$(plugin_read_list PROCESS_TYPE_IMAGES)" ]]; then
-  process_type_images_tmp=$(plugin_read_list PROCESS_TYPE_IMAGES)
-  process_type_images=("${process_type_images_tmp[@]}")
-fi
 
-releasing=()
-if [[ -n "$(plugin_read_list RELEASING)" ]]; then
-  releasing_tmp=$(plugin_read_list RELEASING)
-  releasing=("${releasing_tmp[@]}")
+if [[ -n "$(plugin_read_list PROCESS_TYPE_IMAGES)" ]]; then
+  for process_type_image in $(plugin_read_list PROCESS_TYPE_IMAGES); do
+    process_type_images+=("$process_type_image")
+  done
 fi
 
 if [ ${#process_type_images[@]} -eq 0 ]; then
   # Deprecated process-types in favour of process-type-images
-  process_types_tmp=$(plugin_read_list PROCESS_TYPES)
-  process_type_images=("${process_types_tmp[@]}")
+  for process_type_image in $(plugin_read_list PROCESS_TYPES); do
+    process_type_images+=("$process_type_image")
+  done
   echo "Deprecated Warning: Please use process-type-images instead"
+fi
+
+releasing=()
+
+if [[ -n "$(plugin_read_list RELEASING)" ]]; then
+  for image_name in $(plugin_read_list RELEASING); do
+    releasing+=("$image_name")
+  done
 fi
 
 # Defaults to releasing all proc types
 if [ ${#releasing[@]} -eq 0 ]; then
-  # shellcheck disable=SC2128
-  for line in $process_type_images; do
+  for line in "${process_type_images[@]}"; do
     IFS=':' read -r -a tokens <<< "$line"
     releasing+=("${tokens[0]}")
   done
@@ -90,8 +94,7 @@ fi
 ## Pulling from owner container registry
 ##
 
-# shellcheck disable=SC2128
-for line in $process_type_images; do
+for line in "${process_type_images[@]}"; do
   IFS=':' read -r -a tokens <<< "$line"
   proc_type=${tokens[0]}
   proc_type_image=$(IFS=':'; echo "${tokens[*]:1}")
@@ -118,8 +121,7 @@ done
 ## Tagging for heroku container registry
 ##
 
-# shellcheck disable=SC2128
-for line in $process_type_images; do
+for line in "${process_type_images[@]}"; do
   IFS=':' read -r -a tokens <<< "$line"
   proc_type=${tokens[0]}
   proc_type_image=$(IFS=':'; echo "${tokens[*]:1}")
@@ -137,8 +139,7 @@ done
 echo "~~~ :heroku: Logging into Heroku Docker Registry"
 echo "$HEROKU_API_KEY" | docker login --username=_ --password-stdin registry.heroku.com
 
-# shellcheck disable=SC2128
-for line in $process_type_images; do
+for line in "${process_type_images[@]}"; do
   IFS=':' read -r -a tokens <<< "$line"
   proc_type=${tokens[0]}
   proc_type_image=$(IFS=':'; echo "${tokens[*]:1}")
@@ -165,8 +166,7 @@ echo "+++ :heroku: Releasing ${releasing[*]}"
 
 updates=()
 
-# shellcheck disable=SC2128
-for line in $process_type_images; do
+for line in "${process_type_images[@]}"; do
   IFS=':' read -r -a tokens <<< "$line"
   proc_type=${tokens[0]}
   proc_type_image=$(IFS=':'; echo "${tokens[*]:1}")

--- a/hooks/command
+++ b/hooks/command
@@ -150,12 +150,12 @@ for line in $process_types; do
   proc_type_image=$(IFS=':'; echo "${tokens[*]:1}")
   proc_type_tag=$(get_proc_type_image_tag "$proc_type")
 
+  # Based on https://devcenter.heroku.com/articles/container-registry-and-runtime#getting-a-docker-image-id
+  image_id=$(docker inspect "$proc_type_tag" --format=\{\{.Id\}\})
+  echo "Inspected $proc_type_tag identified as $image_id"
+
   # shellcheck disable=SC2076
   if [[ ! " ${skip_release_types[*]} " =~ " ${proc_type} " ]]; then
-    # Based on https://devcenter.heroku.com/articles/container-registry-and-runtime#getting-a-docker-image-id
-    image_id=$(docker inspect "$proc_type_tag" --format=\{\{.Id\}\})
-
-    echo "Inspected $proc_type_tag identified as $image_id"
     updates+=("{\"type\":\"${proc_type}\",\"docker_image\":\"$image_id\"}")
   fi
 done

--- a/hooks/command
+++ b/hooks/command
@@ -161,7 +161,7 @@ for line in $process_types; do
 done
 
 if [ ${#updates[@]} -eq 0 ]; then
-  echo "There are no images to release"
+  echo "There aren't images to release"
   exit 0
 fi
 

--- a/hooks/command
+++ b/hooks/command
@@ -57,15 +57,41 @@ function get_proc_type_image_tag() {
 }
 
 app=$(plugin_read_list APP)
-process_types=$(plugin_read_list PROCESS_TYPES)
-skip_release_types=$(plugin_read_list SKIP_RELEASE_TYPES)
 
+process_type_images=()
+if [[ -n "$(plugin_read_list PROCESS_TYPE_IMAGES)" ]]; then
+  process_type_images_tmp=$(plugin_read_list PROCESS_TYPE_IMAGES)
+  process_type_images=("${process_type_images_tmp[@]}")
+fi
+
+releasing=()
+if [[ -n "$(plugin_read_list RELEASING)" ]]; then
+  releasing_tmp=$(plugin_read_list RELEASING)
+  releasing=("${releasing_tmp[@]}")
+fi
+
+if [ ${#process_type_images[@]} -eq 0 ]; then
+  # Deprecated process-types in favour of process-type-images
+  process_types_tmp=$(plugin_read_list PROCESS_TYPES)
+  process_type_images=("${process_types_tmp[@]}")
+  echo "Deprecated Warning: Please use process-type-images instead"
+fi
+
+# Defaults to releasing all proc types
+if [ ${#releasing[@]} -eq 0 ]; then
+  # shellcheck disable=SC2128
+  for line in $process_type_images; do
+    IFS=':' read -r -a tokens <<< "$line"
+    releasing+=("${tokens[0]}")
+  done
+fi
 
 ##
 ## Pulling from owner container registry
 ##
 
-for line in $process_types; do
+# shellcheck disable=SC2128
+for line in $process_type_images; do
   IFS=':' read -r -a tokens <<< "$line"
   proc_type=${tokens[0]}
   proc_type_image=$(IFS=':'; echo "${tokens[*]:1}")
@@ -92,7 +118,8 @@ done
 ## Tagging for heroku container registry
 ##
 
-for line in $process_types; do
+# shellcheck disable=SC2128
+for line in $process_type_images; do
   IFS=':' read -r -a tokens <<< "$line"
   proc_type=${tokens[0]}
   proc_type_image=$(IFS=':'; echo "${tokens[*]:1}")
@@ -110,7 +137,8 @@ done
 echo "~~~ :heroku: Logging into Heroku Docker Registry"
 echo "$HEROKU_API_KEY" | docker login --username=_ --password-stdin registry.heroku.com
 
-for line in $process_types; do
+# shellcheck disable=SC2128
+for line in $process_type_images; do
   IFS=':' read -r -a tokens <<< "$line"
   proc_type=${tokens[0]}
   proc_type_image=$(IFS=':'; echo "${tokens[*]:1}")
@@ -133,22 +161,12 @@ done
 ## Releasing to heroku platform
 ##
 
-proc_type_names=()
-for line in $process_types; do
-  IFS=':' read -r -a tokens <<< "$line"
-  proc_type=${tokens[0]}
-
-  # shellcheck disable=SC2076
-  if [[ ! " ${skip_release_types[*]} " =~ " ${proc_type} " ]]; then
-    proc_type_names+=("$proc_type")
-  fi
-done
-
-echo "+++ :heroku: Releasing ${proc_type_names[*]}"
+echo "+++ :heroku: Releasing ${releasing[*]}"
 
 updates=()
 
-for line in $process_types; do
+# shellcheck disable=SC2128
+for line in $process_type_images; do
   IFS=':' read -r -a tokens <<< "$line"
   proc_type=${tokens[0]}
   proc_type_image=$(IFS=':'; echo "${tokens[*]:1}")
@@ -158,7 +176,7 @@ for line in $process_types; do
   image_id=$(docker inspect "$proc_type_tag" --format=\{\{.Id\}\})
 
   # shellcheck disable=SC2076
-  if [[ ! " ${skip_release_types[*]} " =~ " ${proc_type} " ]]; then
+  if [[ " ${releasing[*]} " =~ " ${proc_type} " ]]; then
     echo "Inspected $proc_type_tag identified as $image_id"
     updates+=("{\"type\":\"${proc_type}\",\"docker_image\":\"$image_id\"}")
   else

--- a/plugin.yml
+++ b/plugin.yml
@@ -12,6 +12,6 @@ configuration:
     process-types:
       type: [string, array]
       minimum: 1
-    skip-release:
+    skip-release-types:
       type: [string, array]
   additionalProperties: false

--- a/plugin.yml
+++ b/plugin.yml
@@ -12,6 +12,9 @@ configuration:
     process-types:
       type: [string, array]
       minimum: 1
-    skip-release-types:
+    process-type-images:
+      type: [string, array]
+      minimum: 1
+    releasing:
       type: [string, array]
   additionalProperties: false

--- a/plugin.yml
+++ b/plugin.yml
@@ -12,4 +12,6 @@ configuration:
     process-types:
       type: [string, array]
       minimum: 1
+    skip-release:
+      type: [string, array]
   additionalProperties: false

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -120,7 +120,7 @@ load '/usr/local/lib/bats/load.bash'
 @test "Supports skipping formation patch per proc type" {
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES_0="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES_1="migrations:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations"
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_SKIP_RELEASE_TYPES_0=migrations
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_RELEASING=web
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_APP=my-app
   export HEROKU_API_KEY=api-token
 
@@ -162,7 +162,7 @@ load '/usr/local/lib/bats/load.bash'
 
 @test "Exits gracefully if all proc types are skipped" {
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES="migrations:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations"
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_SKIP_RELEASE_TYPES=migrations
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_RELEASING=web
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_APP=my-app
   export HEROKU_API_KEY=api-token
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -7,8 +7,8 @@ load '/usr/local/lib/bats/load.bash'
 # export CURL_STUB_DEBUG=/dev/tty
 
 @test "By process type pulls, tags and pushes to heroku" {
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES_0="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES_1="release:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_0="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_1="release:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release"
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_APP=my-app
   export HEROKU_API_KEY=api-token
 
@@ -49,8 +49,8 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "By process type finds, tags and pushes to heroku" {
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES_0="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES_1="release:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_0="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_1="release:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release"
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_APP=my-app
   export HEROKU_API_KEY=api-token
 
@@ -89,6 +89,35 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Single process type pulls, tags and pushes to heroku" {
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_APP=my-app
+  export HEROKU_API_KEY=api-token
+
+  stub docker \
+    "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : echo web" \
+    "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web registry.heroku.com/my-app/web:latest : exit 0" \
+    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
+    "push registry.heroku.com/my-app/web:latest : exit 0" \
+    "inspect registry.heroku.com/my-app/web:latest --format={{.Id}} : echo web_id"
+
+  stub curl \
+    '-sf -X PATCH https://api.heroku.com/apps/my-app/formation -d \{\"updates\"\:\[\{\"type\"\:\"web\"\,\"docker_image\"\:\"web_id\"\}\]\} -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3.docker-releases" -H "Authorization: Bearer api-token" -o /dev/null : exit 0' \
+    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"version\":100,\"status\"\:\"succeeded\",\"current\":true\}\]'
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "Found XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
+  assert_output --partial "Tagged XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web as registry.heroku.com/my-app/web:latest"
+  assert_output --partial "Pushed registry.heroku.com/my-app/web:latest"
+  assert_output --partial "Inspected registry.heroku.com/my-app/web:latest identified as web_id"
+  assert_output --partial "Version 100 is current"
+
+  unstub docker
+  unstub curl
+}
+
+@test "Supports deprecated process type attributes" {
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_APP=my-app
   export HEROKU_API_KEY=api-token
@@ -118,8 +147,8 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Supports skipping formation patch per proc type" {
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES_0="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES_1="migrations:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_0="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_1="migrations:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations"
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_RELEASING=web
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_APP=my-app
   export HEROKU_API_KEY=api-token
@@ -161,7 +190,7 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Exits gracefully if all proc types are skipped" {
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES="migrations:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES="migrations:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations"
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_RELEASING=web
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_APP=my-app
   export HEROKU_API_KEY=api-token
@@ -187,7 +216,7 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Polls heroku releases, until success" {
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_APP=my-app
   export HEROKU_API_KEY=api-token
   export RETRY_SLEEP=0
@@ -219,7 +248,7 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Polls heroku releases, until fail" {
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_APP=my-app
   export HEROKU_API_KEY=api-token
   export RETRY_SLEEP=0
@@ -251,7 +280,7 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Stream heroku release output" {
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES="release:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES="release:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release"
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_APP=my-app
   export HEROKU_API_KEY=api-token
   export RETRY_SLEEP=0
@@ -284,8 +313,8 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Fails when an image pull fails" {
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES_0="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES_1="release:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_0="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_1="release:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release"
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_APP=my-app
   export HEROKU_API_KEY=api-token
   export RETRY_SLEEP=0
@@ -308,8 +337,8 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Fails when docker login fails" {
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES_0="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES_1="release:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_0="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_1="release:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release"
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_APP=my-app
   export HEROKU_API_KEY=api-token
 
@@ -334,8 +363,8 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Fails when an image push fails" {
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES_0="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES_1="release:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_0="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_1="release:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release"
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_APP=my-app
   export HEROKU_API_KEY=api-token
   export RETRY_SLEEP=0
@@ -368,8 +397,8 @@ load '/usr/local/lib/bats/load.bash'
 
 
 @test "Fails release image lookup" {
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES_0="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES_1="release:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_0="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_1="release:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release"
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_APP=my-app
   export HEROKU_API_KEY=api-token
 
@@ -406,8 +435,8 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Fails releasing" {
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES_0="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES_1="release:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_0="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_1="release:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release"
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_APP=my-app
   export HEROKU_API_KEY=api-token
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -135,6 +135,7 @@ load '/usr/local/lib/bats/load.bash'
     "push registry.heroku.com/my-app/web:latest : exit 0" \
     "push registry.heroku.com/my-app/migrations:latest : exit 0" \
     "inspect registry.heroku.com/my-app/web:latest --format={{.Id}} : echo web_id" \
+    "inspect registry.heroku.com/my-app/migrations:latest --format={{.Id}} : echo migrations_id"
 
   stub curl \
     '-sf -X PATCH https://api.heroku.com/apps/my-app/formation -d \{\"updates\"\:\[\{\"type\"\:\"web\"\,\"docker_image\"\:\"web_id\"\}\]\} -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3.docker-releases" -H "Authorization: Bearer api-token" -o /dev/null : exit 0' \
@@ -152,7 +153,7 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "Pushed registry.heroku.com/my-app/web:latest"
   assert_output --partial "Pushed registry.heroku.com/my-app/migrations:latest"
   assert_output --partial "Inspected registry.heroku.com/my-app/web:latest identified as web_id"
-  refute_output --partial "Inspected registry.heroku.com/my-app/migrations:latest"
+  assert_output --partial "Inspected registry.heroku.com/my-app/migrations:latest identified as migrations_id"
   assert_output --partial "Version 100 is current"
 
   unstub docker
@@ -170,6 +171,7 @@ load '/usr/local/lib/bats/load.bash'
     "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations registry.heroku.com/my-app/migrations:latest : exit 0" \
     "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "push registry.heroku.com/my-app/migrations:latest : exit 0" \
+    "inspect registry.heroku.com/my-app/migrations:latest --format={{.Id}} : echo migrations_id"
 
   run "$PWD/hooks/command"
 
@@ -177,7 +179,7 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "Found XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations"
   assert_output --partial "Tagged XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations as registry.heroku.com/my-app/migrations:latest"
   assert_output --partial "Pushed registry.heroku.com/my-app/migrations:latest"
-  refute_output --partial "Inspected registry.heroku.com/my-app/migrations:latest"
+  assert_output --partial "Inspected registry.heroku.com/my-app/migrations:latest identified as migrations_id"
   refute_output --partial "Version 100 is current"
 
   unstub docker

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -148,40 +148,52 @@ load '/usr/local/lib/bats/load.bash'
 
 @test "Supports skipping formation patch per proc type" {
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_0="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_1="migrations:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations"
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_RELEASING=web
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_1="worker:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-worker"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_2="migrations:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_RELEASING_0=web
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_RELEASING_1=worker
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_APP=my-app
   export HEROKU_API_KEY=api-token
 
   stub docker \
     "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : exit 0" \
     "pull XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : exit 0" \
+    "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-worker : exit 0" \
+    "pull XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-worker : exit 0" \
     "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations : exit 0" \
     "pull XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations : exit 0" \
     "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web registry.heroku.com/my-app/web:latest : exit 0" \
+    "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-worker registry.heroku.com/my-app/worker:latest : exit 0" \
     "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations registry.heroku.com/my-app/migrations:latest : exit 0" \
     "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "push registry.heroku.com/my-app/web:latest : exit 0" \
+    "push registry.heroku.com/my-app/worker:latest : exit 0" \
     "push registry.heroku.com/my-app/migrations:latest : exit 0" \
     "inspect registry.heroku.com/my-app/web:latest --format={{.Id}} : echo web_id" \
+    "inspect registry.heroku.com/my-app/worker:latest --format={{.Id}} : echo worker_id" \
     "inspect registry.heroku.com/my-app/migrations:latest --format={{.Id}} : echo migrations_id"
 
   stub curl \
-    '-sf -X PATCH https://api.heroku.com/apps/my-app/formation -d \{\"updates\"\:\[\{\"type\"\:\"web\"\,\"docker_image\"\:\"web_id\"\}\]\} -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3.docker-releases" -H "Authorization: Bearer api-token" -o /dev/null : exit 0' \
+    '-sf -X PATCH https://api.heroku.com/apps/my-app/formation -d \{\"updates\"\:\[\{\"type\"\:\"web\"\,\"docker_image\"\:\"web_id\"\},\{\"type\"\:\"worker\"\,\"docker_image\"\:\"worker_id\"\}\]\} -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3.docker-releases" -H "Authorization: Bearer api-token" -o /dev/null : exit 0' \
     '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"version\":100,\"status\"\:\"succeeded\",\"current\":true\}\]'
 
   run "$PWD/hooks/command"
 
   assert_success
   assert_output --partial "Pulled XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
+  assert_output --partial "Pulled XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-worker"
   assert_output --partial "Pulled XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations"
   refute_output --partial "Found XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
+  refute_output --partial "Found XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-worker"
   refute_output --partial "Found XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations"
   assert_output --partial "Tagged XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web as registry.heroku.com/my-app/web:latest"
+  assert_output --partial "Tagged XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-worker as registry.heroku.com/my-app/worker:latest"
   assert_output --partial "Tagged XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations as registry.heroku.com/my-app/migrations:latest"
   assert_output --partial "Pushed registry.heroku.com/my-app/web:latest"
+  assert_output --partial "Pushed registry.heroku.com/my-app/worker:latest"
   assert_output --partial "Pushed registry.heroku.com/my-app/migrations:latest"
   assert_output --partial "Inspected registry.heroku.com/my-app/web:latest identified as web_id"
+  assert_output --partial "Inspected registry.heroku.com/my-app/worker:latest identified as worker_id"
   assert_output --partial "Skipping inspected registry.heroku.com/my-app/migrations:latest identified as migrations_id"
   assert_output --partial "Version 100 is current"
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -117,6 +117,72 @@ load '/usr/local/lib/bats/load.bash'
   unstub curl
 }
 
+@test "Supports skipping formation patch per proc type" {
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES_0="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES_1="migrations:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_SKIP_RELEASE_TYPES_0=migrations
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_APP=my-app
+  export HEROKU_API_KEY=api-token
+
+  stub docker \
+    "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : exit 0" \
+    "pull XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : exit 0" \
+    "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations : exit 0" \
+    "pull XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations : exit 0" \
+    "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web registry.heroku.com/my-app/web:latest : exit 0" \
+    "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations registry.heroku.com/my-app/migrations:latest : exit 0" \
+    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
+    "push registry.heroku.com/my-app/web:latest : exit 0" \
+    "push registry.heroku.com/my-app/migrations:latest : exit 0" \
+    "inspect registry.heroku.com/my-app/web:latest --format={{.Id}} : echo web_id" \
+
+  stub curl \
+    '-sf -X PATCH https://api.heroku.com/apps/my-app/formation -d \{\"updates\"\:\[\{\"type\"\:\"web\"\,\"docker_image\"\:\"web_id\"\}\]\} -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3.docker-releases" -H "Authorization: Bearer api-token" -o /dev/null : exit 0' \
+    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"version\":100,\"status\"\:\"succeeded\",\"current\":true\}\]'
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "Pulled XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
+  assert_output --partial "Pulled XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations"
+  refute_output --partial "Found XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
+  refute_output --partial "Found XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations"
+  assert_output --partial "Tagged XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web as registry.heroku.com/my-app/web:latest"
+  assert_output --partial "Tagged XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations as registry.heroku.com/my-app/migrations:latest"
+  assert_output --partial "Pushed registry.heroku.com/my-app/web:latest"
+  assert_output --partial "Pushed registry.heroku.com/my-app/migrations:latest"
+  assert_output --partial "Inspected registry.heroku.com/my-app/web:latest identified as web_id"
+  refute_output --partial "Inspected registry.heroku.com/my-app/migrations:latest"
+  assert_output --partial "Version 100 is current"
+
+  unstub docker
+  unstub curl
+}
+
+@test "Exits gracefully if all proc types are skipped" {
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES="migrations:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_SKIP_RELEASE_TYPES=migrations
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_APP=my-app
+  export HEROKU_API_KEY=api-token
+
+  stub docker \
+    "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations : echo migrations" \
+    "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations registry.heroku.com/my-app/migrations:latest : exit 0" \
+    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
+    "push registry.heroku.com/my-app/migrations:latest : exit 0" \
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "Found XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations"
+  assert_output --partial "Tagged XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations as registry.heroku.com/my-app/migrations:latest"
+  assert_output --partial "Pushed registry.heroku.com/my-app/migrations:latest"
+  refute_output --partial "Inspected registry.heroku.com/my-app/migrations:latest"
+  refute_output --partial "Version 100 is current"
+
+  unstub docker
+}
+
 @test "Polls heroku releases, until success" {
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPES="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_APP=my-app
@@ -331,7 +397,7 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "Pushed registry.heroku.com/my-app/release:latest"
   assert_output --partial "Inspected registry.heroku.com/my-app/web:latest identified as web_id"
   refute_output --partial "Inspected registry.heroku.com/my-app/release:latest identified as release_id"
-  refute_output --partial "Released web release"
+  refute_output --partial "Version 100 is current"
 
   unstub docker
 }
@@ -369,7 +435,7 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "Pushed registry.heroku.com/my-app/release:latest"
   assert_output --partial "Inspected registry.heroku.com/my-app/web:latest identified as web_id"
   assert_output --partial "Inspected registry.heroku.com/my-app/release:latest identified as release_id"
-  refute_output --partial "Released web release"
+  refute_output --partial "Version 100 is current"
 
   unstub docker
 }

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -180,6 +180,7 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "Tagged XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations as registry.heroku.com/my-app/migrations:latest"
   assert_output --partial "Pushed registry.heroku.com/my-app/migrations:latest"
   assert_output --partial "Inspected registry.heroku.com/my-app/migrations:latest identified as migrations_id"
+  assert_output --partial "There aren't images to release"
   refute_output --partial "Version 100 is current"
 
   unstub docker

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -153,7 +153,7 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "Pushed registry.heroku.com/my-app/web:latest"
   assert_output --partial "Pushed registry.heroku.com/my-app/migrations:latest"
   assert_output --partial "Inspected registry.heroku.com/my-app/web:latest identified as web_id"
-  assert_output --partial "Inspected registry.heroku.com/my-app/migrations:latest identified as migrations_id"
+  assert_output --partial "Skipping inspected registry.heroku.com/my-app/migrations:latest identified as migrations_id"
   assert_output --partial "Version 100 is current"
 
   unstub docker
@@ -179,7 +179,7 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "Found XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations"
   assert_output --partial "Tagged XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations as registry.heroku.com/my-app/migrations:latest"
   assert_output --partial "Pushed registry.heroku.com/my-app/migrations:latest"
-  assert_output --partial "Inspected registry.heroku.com/my-app/migrations:latest identified as migrations_id"
+  assert_output --partial "Skipping inspected registry.heroku.com/my-app/migrations:latest identified as migrations_id"
   assert_output --partial "There aren't images to release"
   refute_output --partial "Version 100 is current"
 


### PR DESCRIPTION
## Description

Sometimes you have an image that isn't being deployed, but the image artifact needs to be pulled and pushing with the same deployment as other images.

This PR changes:

* Renames `process-types` to a clearer `process-type-images` and supports both for now.

* Introduce optional `releasing` prop that can list a subset of images to release (defaults to all, except `migrations`). It's a list of process type names to be released. It will always pull, tag and push all images, but it will only patch the Heroku Formation API with these images.

eg. `web` and `migrations` and pushed to heroku, but only `web` is updated in the formation API (deployment)

```yml
steps:
  - label: ":heroku: Deploy my-app app (web)"
    plugins:
      - envato/heroku-container-deploy#v1.1.0:
          app: my-app
          process-type-images:
            - web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web-${BUILDKITE_COMMIT}
            - migrations:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations-${BUILDKITE_COMMIT}
          releasing:
            - web
```

## Screenshot

See `migration` is omitted from "releasing"

<img src="https://user-images.githubusercontent.com/201552/149703079-467614c5-9999-4845-a9e3-994182995eb5.png" width="400" />
