### PR TITLE
Fail streaming release output gracefully (v1.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Deploy a pre-built images from ECR to heroku container registry.
 steps:
   - label: ":heroku: Deploy my-app app (web)"
     plugins:
-      - envato/heroku-container-deploy#v1.1.0:
+      - envato/heroku-container-deploy#v1.2.0:
           app: my-app
           process-type-images:
             - web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web-${BUILDKITE_COMMIT}
@@ -26,7 +26,7 @@ Deploy multiple pre-built images from ECR to heroku container registry.
 steps:
   - label: ":heroku: Deploy my-app app (web and worker)"
     plugins:
-      - envato/heroku-container-deploy#v1.1.0:
+      - envato/heroku-container-deploy#v1.2.0:
           app: my-app
           process-type-images:
             - web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web-${BUILDKITE_COMMIT}
@@ -39,7 +39,7 @@ Deploy multiple pre-built images including a [Release Phase](https://devcenter.h
 steps:
   - label: ":heroku: Deploy my-app app (web, worker and release)"
     plugins:
-      - envato/heroku-container-deploy#v1.1.0:
+      - envato/heroku-container-deploy#v1.2.0:
           app: my-app
           process-type-images:
             - web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web-${BUILDKITE_COMMIT}

--- a/hooks/command
+++ b/hooks/command
@@ -226,6 +226,7 @@ function check_release() {
     local current; current=$(echo "$latest_release" | jq -r '.[0].current')
     local status; status=$(echo "$latest_release" | jq -r '.[0].status')
     local output_stream_url; output_stream_url=$(echo "$latest_release" | jq -r '.[0].output_stream_url')
+    local release_id; release_id=$(echo "$latest_release" | jq -r '.[0].id')
     local summary; summary="[heroku version=$version, current=$current, status=$status]"
 
     if [ $streamed -eq 0 ] && [ "$status" == "pending" ] && [ "$output_stream_url" != "null" ]; then
@@ -242,8 +243,9 @@ function check_release() {
       if [ $status -eq 0 ]; then
         continue;
       else
-        echo "Failed streaming release output: $output_stream_url"
-        exit 1
+        echo "Continuing without streaming release output, url: $output_stream_url"
+        echo "--> You can view the release logs in the heroku dashboard."
+        echo "--> https://dashboard.heroku.com/apps/$app/activity/releases/$release_id"
       fi
     fi
 

--- a/hooks/command
+++ b/hooks/command
@@ -210,6 +210,7 @@ version=""
 function check_release() {
   local count=0
   local streamed=0
+  local max_polling_retries=30
   while true;
   do
     count=$((count + 1))
@@ -246,6 +247,7 @@ function check_release() {
         echo "Continuing without streaming release output, url: $output_stream_url"
         echo "--> You can view the release logs in the heroku dashboard."
         echo "--> https://dashboard.heroku.com/apps/$app/activity/releases/$release_id"
+        max_polling_retries=60
       fi
     fi
 
@@ -259,7 +261,7 @@ function check_release() {
       exit 1
     fi
 
-    if [ $count -gt 15 ]; then
+    if [ $count -gt $max_polling_retries ]; then
       echo "$summary timeout"
       exit 1
     fi

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -27,7 +27,7 @@ load '/usr/local/lib/bats/load.bash'
 
   stub curl \
     '-sf -X PATCH https://api.heroku.com/apps/my-app/formation -d \{\"updates\"\:\[\{\"type\"\:\"web\"\,\"docker_image\"\:\"web_id\"\}\,\{\"type\"\:\"release\"\,\"docker_image\"\:\"release_id\"\}\]\} -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3.docker-releases" -H "Authorization: Bearer api-token" -o /dev/null : exit 0' \
-    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"version\":100,\"status\"\:\"succeeded\",\"current\":true\}\]'
+    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"id\"\:\"app_id\",\"version\":100,\"status\"\:\"succeeded\",\"current\":true\}\]'
 
   run "$PWD/hooks/command"
 
@@ -67,7 +67,7 @@ load '/usr/local/lib/bats/load.bash'
 
   stub curl \
     '-sf -X PATCH https://api.heroku.com/apps/my-app/formation -d \{\"updates\"\:\[\{\"type\"\:\"web\"\,\"docker_image\"\:\"web_id\"\}\,\{\"type\"\:\"release\"\,\"docker_image\"\:\"release_id\"\}\]\} -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3.docker-releases" -H "Authorization: Bearer api-token" -o /dev/null : exit 0' \
-    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"version\":100,\"status\"\:\"succeeded\",\"current\":true\}\]'
+    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"id\"\:\"app_id\",\"version\":100,\"status\"\:\"succeeded\",\"current\":true\}\]'
 
   run "$PWD/hooks/command"
 
@@ -102,7 +102,7 @@ load '/usr/local/lib/bats/load.bash'
 
   stub curl \
     '-sf -X PATCH https://api.heroku.com/apps/my-app/formation -d \{\"updates\"\:\[\{\"type\"\:\"web\"\,\"docker_image\"\:\"web_id\"\}\]\} -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3.docker-releases" -H "Authorization: Bearer api-token" -o /dev/null : exit 0' \
-    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"version\":100,\"status\"\:\"succeeded\",\"current\":true\}\]'
+    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"id\"\:\"app_id\",\"version\":100,\"status\"\:\"succeeded\",\"current\":true\}\]'
 
   run "$PWD/hooks/command"
 
@@ -131,7 +131,7 @@ load '/usr/local/lib/bats/load.bash'
 
   stub curl \
     '-sf -X PATCH https://api.heroku.com/apps/my-app/formation -d \{\"updates\"\:\[\{\"type\"\:\"web\"\,\"docker_image\"\:\"web_id\"\}\]\} -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3.docker-releases" -H "Authorization: Bearer api-token" -o /dev/null : exit 0' \
-    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"version\":100,\"status\"\:\"succeeded\",\"current\":true\}\]'
+    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"id\"\:\"app_id\",\"version\":100,\"status\"\:\"succeeded\",\"current\":true\}\]'
 
   run "$PWD/hooks/command"
 
@@ -175,7 +175,7 @@ load '/usr/local/lib/bats/load.bash'
 
   stub curl \
     '-sf -X PATCH https://api.heroku.com/apps/my-app/formation -d \{\"updates\"\:\[\{\"type\"\:\"web\"\,\"docker_image\"\:\"web_id\"\},\{\"type\"\:\"worker\"\,\"docker_image\"\:\"worker_id\"\}\]\} -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3.docker-releases" -H "Authorization: Bearer api-token" -o /dev/null : exit 0' \
-    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"version\":100,\"status\"\:\"succeeded\",\"current\":true\}\]'
+    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"id\"\:\"app_id\",\"version\":100,\"status\"\:\"succeeded\",\"current\":true\}\]'
 
   run "$PWD/hooks/command"
 
@@ -248,7 +248,7 @@ load '/usr/local/lib/bats/load.bash'
 
   stub curl \
     '-sf -X PATCH https://api.heroku.com/apps/my-app/formation -d \{\"updates\"\:\[\{\"type\"\:\"web\"\,\"docker_image\"\:\"web_id\"\}\]\} -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3.docker-releases" -H "Authorization: Bearer api-token" -o /dev/null : exit 0' \
-    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"version\":100,\"status\"\:\"succeeded\",\"current\":true\}\]'
+    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"id\"\:\"app_id\",\"version\":100,\"status\"\:\"succeeded\",\"current\":true\}\]'
 
   run "$PWD/hooks/command"
 
@@ -284,9 +284,9 @@ load '/usr/local/lib/bats/load.bash'
 
   stub curl \
     '-sf -X PATCH https://api.heroku.com/apps/my-app/formation -d \{\"updates\"\:\[\{\"type\"\:\"web\"\,\"docker_image\"\:\"web_id\"\}\]\} -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3.docker-releases" -H "Authorization: Bearer api-token" -o /dev/null : exit 0' \
-    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"version\":100,\"status\"\:\"pending\",\"current\":false\}\]' \
-    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"version\":100,\"status\"\:\"pending\",\"current\":false\}\]' \
-    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"version\":100,\"status\"\:\"succeeded\",\"current\":true\}\]'
+    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"id\"\:\"app_id\",\"version\":100,\"status\"\:\"pending\",\"current\":false\}\]' \
+    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"id\"\:\"app_id\",\"version\":100,\"status\"\:\"pending\",\"current\":false\}\]' \
+    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"id\"\:\"app_id\",\"version\":100,\"status\"\:\"succeeded\",\"current\":true\}\]'
 
   run "$PWD/hooks/command"
 
@@ -316,9 +316,9 @@ load '/usr/local/lib/bats/load.bash'
 
   stub curl \
     '-sf -X PATCH https://api.heroku.com/apps/my-app/formation -d \{\"updates\"\:\[\{\"type\"\:\"web\"\,\"docker_image\"\:\"web_id\"\}\]\} -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3.docker-releases" -H "Authorization: Bearer api-token" -o /dev/null : exit 0' \
-    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"version\":100,\"status\"\:\"pending\",\"current\":false\}\]' \
-    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"version\":100,\"status\"\:\"pending\",\"current\":false\}\]' \
-    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"version\":100,\"status\"\:\"failed\",\"current\":false\}\]'
+    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"id\"\:\"app_id\",\"version\":100,\"status\"\:\"pending\",\"current\":false\}\]' \
+    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"id\"\:\"app_id\",\"version\":100,\"status\"\:\"pending\",\"current\":false\}\]' \
+    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"id\"\:\"app_id\",\"version\":100,\"status\"\:\"failed\",\"current\":false\}\]'
 
   run "$PWD/hooks/command"
 
@@ -348,10 +348,10 @@ load '/usr/local/lib/bats/load.bash'
 
   stub curl \
     '-sf -X PATCH https://api.heroku.com/apps/my-app/formation -d \{\"updates\"\:\[\{\"type\"\:\"release\"\,\"docker_image\"\:\"release_id\"\}\]\} -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3.docker-releases" -H "Authorization: Bearer api-token" -o /dev/null : exit 0' \
-    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"version\":100,\"status\"\:\"pending\",\"current\":false,\"output_stream_url\":\"release_output_stream_url\"\}\]' \
+    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"id\"\:\"app_id\",\"version\":100,\"status\"\:\"pending\",\"current\":false,\"output_stream_url\":\"release_output_stream_url\"\}\]' \
     '-sf release_output_stream_url -H "Accept: text/event-stream" : echo "id: 1" && echo "data: Release Output"' \
-    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"version\":100,\"status\"\:\"pending\",\"current\":false,\"output_stream_url\":\"release_output_stream_url\"\}\]' \
-    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"version\":100,\"status\"\:\"succeeded\",\"current\":true,\"output_stream_url\":\"release_output_stream_url\"\}\]'
+    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"id\"\:\"app_id\",\"version\":100,\"status\"\:\"pending\",\"current\":false,\"output_stream_url\":\"release_output_stream_url\"\}\]' \
+    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"id\"\:\"app_id\",\"version\":100,\"status\"\:\"succeeded\",\"current\":true,\"output_stream_url\":\"release_output_stream_url\"\}\]'
 
   run "$PWD/hooks/command"
 
@@ -360,6 +360,44 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "Tagged XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release as registry.heroku.com/my-app/release:latest"
   assert_output --partial "Pushed registry.heroku.com/my-app/release:latest"
   assert_output --partial "Inspected registry.heroku.com/my-app/release:latest identified as release_id"
+  assert_output --partial "data: Release Output"
+  refute_output --partial "Continuing without streaming release output"
+  assert_output --partial "Version 100 is current"
+
+  unstub docker
+  unstub curl
+}
+
+@test "Continue polling when stream heroku release output fails" {
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES="release:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release"
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_APP=my-app
+  export HEROKU_API_KEY=api-token
+  export RETRY_SLEEP=0
+
+  stub docker \
+    "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release : echo release" \
+    "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release registry.heroku.com/my-app/release:latest : exit 0" \
+    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
+    "push registry.heroku.com/my-app/release:latest : exit 0" \
+    "inspect registry.heroku.com/my-app/release:latest --format={{.Id}} : echo release_id"
+
+  stub curl \
+    '-sf -X PATCH https://api.heroku.com/apps/my-app/formation -d \{\"updates\"\:\[\{\"type\"\:\"release\"\,\"docker_image\"\:\"release_id\"\}\]\} -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3.docker-releases" -H "Authorization: Bearer api-token" -o /dev/null : exit 0' \
+    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"id\"\:\"app_id\",\"version\":100,\"status\"\:\"pending\",\"current\":false,\"output_stream_url\":\"release_output_stream_url\"\}\]' \
+    '-sf release_output_stream_url -H "Accept: text/event-stream" : exit 1' \
+    '-sf release_output_stream_url -H "Accept: text/event-stream" : exit 1' \
+    '-sf release_output_stream_url -H "Accept: text/event-stream" : exit 1' \
+    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"id\"\:\"app_id\",\"version\":100,\"status\"\:\"pending\",\"current\":false,\"output_stream_url\":\"release_output_stream_url\"\}\]' \
+    '-sf https://api.heroku.com/apps/my-app/releases -H "Content-Type: application/json" -H "Accept: application/vnd.heroku+json; version=3" -H "Range: version ..; max=1, order=desc" -H "Authorization: Bearer api-token" : echo \[\{\"id\"\:\"app_id\",\"version\":100,\"status\"\:\"succeeded\",\"current\":true,\"output_stream_url\":\"release_output_stream_url\"\}\]'
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "Found XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release"
+  assert_output --partial "Tagged XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release as registry.heroku.com/my-app/release:latest"
+  assert_output --partial "Pushed registry.heroku.com/my-app/release:latest"
+  assert_output --partial "Inspected registry.heroku.com/my-app/release:latest identified as release_id"
+  assert_output --partial "Continuing without streaming release output"
   assert_output --partial "Version 100 is current"
 
   unstub docker


### PR DESCRIPTION
## Description

Sometimes the release output fails without explanation (even though we retry). Because the release can still succeed, it's better to continue polling the release api until it succeeds or fails. Otherwise we might have a false failure
