### PR TITLE
Support specifying the API key environment variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,13 @@ steps:
 
 ## Configuration
 
-Ensure that you have an `HEROKU_API_KEY` environment variable configured for your agent/repo.
-
 ### `app` (Required, string)
 
 Heroku app name
+
+### `key-name` (Optional, string)
+
+The name of the environment variable that contains the Heroku API key. Defaults to `HEROKU_API_KEY`
 
 ### `process-type-images` (Required, Array of string)
 

--- a/hooks/command
+++ b/hooks/command
@@ -101,6 +101,13 @@ if [ ${#releasing[@]} -eq 0 ]; then
 fi
 
 ##
+## Log in to the heroku registry early, in case the images are already there
+##
+
+echo "~~~ :heroku: Logging into Heroku Docker Registry"
+echo "$heroku_api_key" | docker login --username=_ --password-stdin registry.heroku.com
+
+##
 ## Pulling from owner container registry
 ##
 
@@ -150,9 +157,6 @@ done
 ##
 ## Pushing to heroku container registry
 ##
-
-echo "~~~ :heroku: Logging into Heroku Docker Registry"
-echo "$heroku_api_key" | docker login --username=_ --password-stdin registry.heroku.com
 
 for line in "${process_type_images[@]}"; do
   IFS=':' read -r -a tokens <<< "$line"

--- a/hooks/command
+++ b/hooks/command
@@ -48,8 +48,10 @@ retry() {
   return 0
 }
 
+heroku_registry_host="registry.heroku.com"
+
 function get_proc_type_image_tag() {
-  echo "registry.heroku.com/$app/$1:latest"
+  echo "$heroku_registry_host/$app/$1:latest"
 }
 
 key_name=$(plugin_read_list KEY_NAME)
@@ -108,7 +110,12 @@ for line in "${process_type_images[@]}"; do
   proc_type_image=$(IFS=':'; echo "${tokens[*]:1}")
   proc_type_image_id=$(docker images -q "$proc_type_image")
 
-  echo "~~~ :docker: Pulling $proc_type image"
+  emoji=":docker:"
+  if [[ "$proc_type_image" =~ $heroku_registry_host ]]; then
+    emoji=":heroku:"
+  fi
+
+  echo "~~~ $emoji Pulling $proc_type image"
   if [ -z "${proc_type_image_id}" ]; then
     status=0
     if ! retry 3 docker pull "$proc_type_image"; then
@@ -135,7 +142,7 @@ for line in "${process_type_images[@]}"; do
   proc_type_image=$(IFS=':'; echo "${tokens[*]:1}")
   proc_type_tag=$(get_proc_type_image_tag "$proc_type")
 
-  echo "~~~ :heroku: Tagging ${proc_type} image"
+  echo "~~~ :heroku: Tagging $app/${proc_type} image"
   docker tag "$proc_type_image" "$proc_type_tag"
   echo "Tagged $proc_type_image as $proc_type_tag"
 done

--- a/hooks/command
+++ b/hooks/command
@@ -218,7 +218,7 @@ curl -sf -X PATCH "https://api.heroku.com/apps/$app/formation" \
   -d "{\"updates\":[$payload]}" \
   -H "Content-Type: application/json" \
   -H "Accept: application/vnd.heroku+json; version=3.docker-releases" \
-  -H "Authorization: Bearer ${HEROKU_API_KEY:-}" \
+  -H "Authorization: Bearer ${heroku_api_key:-}" \
   -o /dev/null
 
 version=""
@@ -237,7 +237,7 @@ function check_release() {
       -H "Content-Type: application/json" \
       -H "Accept: application/vnd.heroku+json; version=3" \
       -H "Range: version ..; max=1, order=desc" \
-      -H "Authorization: Bearer ${HEROKU_API_KEY:-}")
+      -H "Authorization: Bearer ${heroku_api_key:-}")
 
     version=$(echo "$latest_release" | jq -r '.[0].version')
     local current; current=$(echo "$latest_release" | jq -r '.[0].current')

--- a/hooks/command
+++ b/hooks/command
@@ -4,10 +4,6 @@ set -ue
 
 retry_sleep=${RETRY_SLEEP:-2}
 
-if [ -z "${HEROKU_API_KEY:-}" ]; then
-  echo "Missing required HEROKU_API_KEY"
-  exit 1
-fi
 
 function join_by { local IFS="$1"; shift; echo "$*"; }
 
@@ -55,6 +51,15 @@ retry() {
 function get_proc_type_image_tag() {
   echo "registry.heroku.com/$app/$1:latest"
 }
+
+key_name=$(plugin_read_list KEY_NAME)
+key_name="${key_name:-HEROKU_API_KEY}"
+heroku_api_key=$(printf '%s\n' "${!key_name-}")
+
+if [ -z "${heroku_api_key}" ]; then
+  echo "Missing heroku api key. Required HEROKU_API_KEY or \"key-name\""
+  exit 1
+fi
 
 app=$(plugin_read_list APP)
 
@@ -140,7 +145,7 @@ done
 ##
 
 echo "~~~ :heroku: Logging into Heroku Docker Registry"
-echo "$HEROKU_API_KEY" | docker login --username=_ --password-stdin registry.heroku.com
+echo "$heroku_api_key" | docker login --username=_ --password-stdin registry.heroku.com
 
 for line in "${process_type_images[@]}"; do
   IFS=':' read -r -a tokens <<< "$line"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ue
+
+echo "~~~ :heroku: Logging out of Heroku Docker Registry"
+docker logout registry.heroku.com

--- a/plugin.yml
+++ b/plugin.yml
@@ -9,6 +9,8 @@ configuration:
   properties:
     app:
       type: string
+    key-name:
+      type: string
     process-types:
       type: [string, array]
       minimum: 1

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -13,13 +13,13 @@ load '/usr/local/lib/bats/load.bash'
   export HEROKU_API_KEY=api-token
 
   stub docker \
+    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : exit 0" \
     "pull XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : exit 0" \
     "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release : exit 0" \
     "pull XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release : exit 0" \
     "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web registry.heroku.com/my-app/web:latest : exit 0" \
     "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release registry.heroku.com/my-app/release:latest : exit 0" \
-    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "push registry.heroku.com/my-app/web:latest : exit 0" \
     "push registry.heroku.com/my-app/release:latest : exit 0" \
     "inspect registry.heroku.com/my-app/web:latest --format={{.Id}} : echo web_id" \
@@ -55,11 +55,11 @@ load '/usr/local/lib/bats/load.bash'
   export HEROKU_API_KEY=api-token
 
   stub docker \
+    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : echo web" \
     "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release : echo release" \
     "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web registry.heroku.com/my-app/web:latest : exit 0" \
     "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release registry.heroku.com/my-app/release:latest : exit 0" \
-    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "push registry.heroku.com/my-app/web:latest : exit 0" \
     "push registry.heroku.com/my-app/release:latest : exit 0" \
     "inspect registry.heroku.com/my-app/web:latest --format={{.Id}} : echo web_id" \
@@ -94,9 +94,9 @@ load '/usr/local/lib/bats/load.bash'
   export HEROKU_API_KEY=api-token
 
   stub docker \
+    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : echo web" \
     "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web registry.heroku.com/my-app/web:latest : exit 0" \
-    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "push registry.heroku.com/my-app/web:latest : exit 0" \
     "inspect registry.heroku.com/my-app/web:latest --format={{.Id}} : echo web_id"
 
@@ -123,9 +123,9 @@ load '/usr/local/lib/bats/load.bash'
   export HEROKU_API_KEY=api-token
 
   stub docker \
+    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : echo web" \
     "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web registry.heroku.com/my-app/web:latest : exit 0" \
-    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "push registry.heroku.com/my-app/web:latest : exit 0" \
     "inspect registry.heroku.com/my-app/web:latest --format={{.Id}} : echo web_id"
 
@@ -156,6 +156,7 @@ load '/usr/local/lib/bats/load.bash'
   export HEROKU_API_KEY=api-token
 
   stub docker \
+    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : exit 0" \
     "pull XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : exit 0" \
     "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-worker : exit 0" \
@@ -165,7 +166,6 @@ load '/usr/local/lib/bats/load.bash'
     "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web registry.heroku.com/my-app/web:latest : exit 0" \
     "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-worker registry.heroku.com/my-app/worker:latest : exit 0" \
     "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations registry.heroku.com/my-app/migrations:latest : exit 0" \
-    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "push registry.heroku.com/my-app/web:latest : exit 0" \
     "push registry.heroku.com/my-app/worker:latest : exit 0" \
     "push registry.heroku.com/my-app/migrations:latest : exit 0" \
@@ -208,9 +208,9 @@ load '/usr/local/lib/bats/load.bash'
   export HEROKU_API_KEY=api-token
 
   stub docker \
+    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations : echo migrations" \
     "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations registry.heroku.com/my-app/migrations:latest : exit 0" \
-    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "push registry.heroku.com/my-app/migrations:latest : exit 0" \
     "inspect registry.heroku.com/my-app/migrations:latest --format={{.Id}} : echo migrations_id"
 
@@ -234,13 +234,13 @@ load '/usr/local/lib/bats/load.bash'
   export HEROKU_API_KEY=api-token
 
   stub docker \
+    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : exit 0" \
     "pull XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : exit 0" \
     "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations : exit 0" \
     "pull XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations : exit 0" \
     "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web registry.heroku.com/my-app/web:latest : exit 0" \
     "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-migrations registry.heroku.com/my-app/migrations:latest : exit 0" \
-    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "push registry.heroku.com/my-app/web:latest : exit 0" \
     "push registry.heroku.com/my-app/migrations:latest : exit 0" \
     "inspect registry.heroku.com/my-app/web:latest --format={{.Id}} : echo web_id" \
@@ -276,9 +276,9 @@ load '/usr/local/lib/bats/load.bash'
   export RETRY_SLEEP=0
 
   stub docker \
+    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : echo web" \
     "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web registry.heroku.com/my-app/web:latest : exit 0" \
-    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "push registry.heroku.com/my-app/web:latest : exit 0" \
     "inspect registry.heroku.com/my-app/web:latest --format={{.Id}} : echo web_id"
 
@@ -308,9 +308,9 @@ load '/usr/local/lib/bats/load.bash'
   export RETRY_SLEEP=0
 
   stub docker \
+    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : echo web" \
     "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web registry.heroku.com/my-app/web:latest : exit 0" \
-    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "push registry.heroku.com/my-app/web:latest : exit 0" \
     "inspect registry.heroku.com/my-app/web:latest --format={{.Id}} : echo web_id"
 
@@ -340,9 +340,9 @@ load '/usr/local/lib/bats/load.bash'
   export RETRY_SLEEP=0
 
   stub docker \
+    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release : echo release" \
     "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release registry.heroku.com/my-app/release:latest : exit 0" \
-    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "push registry.heroku.com/my-app/release:latest : exit 0" \
     "inspect registry.heroku.com/my-app/release:latest --format={{.Id}} : echo release_id"
 
@@ -375,9 +375,9 @@ load '/usr/local/lib/bats/load.bash'
   export RETRY_SLEEP=0
 
   stub docker \
+    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release : echo release" \
     "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release registry.heroku.com/my-app/release:latest : exit 0" \
-    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "push registry.heroku.com/my-app/release:latest : exit 0" \
     "inspect registry.heroku.com/my-app/release:latest --format={{.Id}} : echo release_id"
 
@@ -412,6 +412,7 @@ load '/usr/local/lib/bats/load.bash'
   export RETRY_SLEEP=0
 
   stub docker \
+    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : exit 0" \
     "pull XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : exit 0" \
     "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release : exit 0" \
@@ -429,55 +430,31 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Fails when docker login fails" {
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_0="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_1="release:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release"
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_APP=my-app
   export HEROKU_API_KEY=api-token
 
   stub docker \
-    "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : exit 0" \
-    "pull XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : exit 0" \
-    "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release : exit 0" \
-    "pull XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release : exit 0" \
-    "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web registry.heroku.com/my-app/web:latest : exit 0" \
-    "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release registry.heroku.com/my-app/release:latest : exit 0" \
     "login --username=_ --password-stdin registry.heroku.com : exit 1"
 
   run "$PWD/hooks/command"
 
   assert_failure
-  assert_output --partial "Pulled XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
-  assert_output --partial "Pulled XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release"
-  assert_output --partial "Tagged XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web as registry.heroku.com/my-app/web:latest"
-  assert_output --partial "Tagged XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release as registry.heroku.com/my-app/release:latest"
 
   unstub docker
 }
 
 @test "Fails when docker login fails with specified key" {
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_0="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
-  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_1="release:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release"
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_APP=my-app
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_KEY_NAME=MY_HEROKU_KEY
   export HEROKU_API_KEY=irrelevant
   export MY_HEROKU_KEY=api-token
 
   stub docker \
-    "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : exit 0" \
-    "pull XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : exit 0" \
-    "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release : exit 0" \
-    "pull XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release : exit 0" \
-    "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web registry.heroku.com/my-app/web:latest : exit 0" \
-    "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release registry.heroku.com/my-app/release:latest : exit 0" \
     "login --username=_ --password-stdin registry.heroku.com : exit 1"
 
   run "$PWD/hooks/command"
 
   assert_failure
-  assert_output --partial "Pulled XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
-  assert_output --partial "Pulled XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release"
-  assert_output --partial "Tagged XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web as registry.heroku.com/my-app/web:latest"
-  assert_output --partial "Tagged XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release as registry.heroku.com/my-app/release:latest"
 
   unstub docker
 }
@@ -490,13 +467,13 @@ load '/usr/local/lib/bats/load.bash'
   export RETRY_SLEEP=0
 
   stub docker \
+    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : exit 0" \
     "pull XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : exit 0" \
     "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release : exit 0" \
     "pull XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release : exit 0" \
     "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web registry.heroku.com/my-app/web:latest : exit 0" \
     "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release registry.heroku.com/my-app/release:latest : exit 0" \
-    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "push registry.heroku.com/my-app/web:latest : exit 0" \
     "push registry.heroku.com/my-app/release:latest : exit 1" \
     "push registry.heroku.com/my-app/release:latest : exit 1" \
@@ -523,13 +500,13 @@ load '/usr/local/lib/bats/load.bash'
   export HEROKU_API_KEY=api-token
 
   stub docker \
+    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : exit 0" \
     "pull XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : exit 0" \
     "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release : exit 0" \
     "pull XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release : exit 0" \
     "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web registry.heroku.com/my-app/web:latest : exit 0" \
     "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release registry.heroku.com/my-app/release:latest : exit 0" \
-    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "push registry.heroku.com/my-app/web:latest : exit 0" \
     "push registry.heroku.com/my-app/release:latest : exit 0" \
     "inspect registry.heroku.com/my-app/web:latest --format={{.Id}} : echo web_id" \
@@ -561,13 +538,13 @@ load '/usr/local/lib/bats/load.bash'
   export HEROKU_API_KEY=api-token
 
   stub docker \
+    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : exit 0" \
     "pull XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web : exit 0" \
     "images -q XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release : exit 0" \
     "pull XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release : exit 0" \
     "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web registry.heroku.com/my-app/web:latest : exit 0" \
     "tag XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release registry.heroku.com/my-app/release:latest : exit 0" \
-    "login --username=_ --password-stdin registry.heroku.com : exit 0" \
     "push registry.heroku.com/my-app/web:latest : exit 0" \
     "push registry.heroku.com/my-app/release:latest : exit 0" \
     "inspect registry.heroku.com/my-app/web:latest --format={{.Id}} : echo web_id" \

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -52,7 +52,9 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_0="web:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-web"
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_PROCESS_TYPE_IMAGES_1="release:XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:heroku-release"
   export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_APP=my-app
-  export HEROKU_API_KEY=api-token
+  export BUILDKITE_PLUGIN_HEROKU_CONTAINER_DEPLOY_KEY_NAME=MY_HEROKU_KEY
+  export HEROKU_API_KEY=irrelevant
+  export MY_HEROKU_KEY=api-token
 
   stub docker \
     "login --username=_ --password-stdin registry.heroku.com : exit 0" \

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -1,0 +1,19 @@
+#!/usr/bin/env bats
+
+load '/usr/local/lib/bats/load.bash'
+
+# Uncomment the following line to debug stub failures
+# export DOCKER_STUB_DEBUG=/dev/tty
+# export CURL_STUB_DEBUG=/dev/tty
+
+@test "Docker logout" {
+  stub docker \
+    "logout registry.heroku.com : exit 0"
+
+  run "$PWD/hooks/post-command"
+
+  assert_success
+
+  unstub docker
+}
+


### PR DESCRIPTION
## Changes

* Adds a new plugin param called `key-name` which defaults to `HEROKU_API_KEY`
* Changes the Heroku Registry login to be the first thing it does so that it fails fast.
* Adds docker logout as a post-command clean up
* Minor logging tweaks

