### PR TITLE
Print the time when the new version becomes active

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -289,4 +289,4 @@ function check_release() {
 
 check_release
 
-echo "Version $version is current."
+echo "$(date) Version $version is current."


### PR DESCRIPTION
From the buildkite deploy log it's not trivial to tell when the new version became active.
Add a timestamp to the last message to make debugging / searching logs easier.